### PR TITLE
Expose a type for PathSegment

### DIFF
--- a/Data/FilePath.hs
+++ b/Data/FilePath.hs
@@ -3,6 +3,7 @@ module Data.FilePath
     (   Path(..)
     ,   From(..)
     ,   PathSegment
+    ,   segString
     ,   mkPathSegment
     ,   FilePath
     ,   (</>)
@@ -33,7 +34,7 @@ import GHC.Types
 -- two \'\/\' characters.  Valid path segments cannot contain \'\/\' or control
 -- characters.  PathSegments are also monoids to allow mappending with
 -- prefixes/suffixes.
-newtype PathSegment = PathSegment { unSegment :: String }
+newtype PathSegment = PathSegment { segString :: String }
   deriving (Eq,Show,Typeable,Data)
 
 instance Monoid PathSegment where
@@ -105,8 +106,8 @@ mkFullFilePath _ = Nothing -- all full file paths must start from /
 dirname :: FilePath a File -> FilePath a Directory
 dirname (FilePath dir _) = dir
 
-basename :: FilePath a File -> String
-basename (FilePath _ (PathSegment bname)) = bname
+basename :: FilePath a File -> PathSegment
+basename (FilePath _ bname) = bname
 
 showp :: FilePath a b -> String
 showp RootPath = ""

--- a/Data/FilePath.hs
+++ b/Data/FilePath.hs
@@ -106,8 +106,11 @@ mkFullFilePath _ = Nothing -- all full file paths must start from /
 dirname :: FilePath a File -> FilePath a Directory
 dirname (FilePath dir _) = dir
 
-basename :: FilePath a File -> PathSegment
-basename (FilePath _ bname) = bname
+basename :: FilePath a File -> String
+basename (FilePath _ (PathSegment bname)) = bname
+
+basenameSeg :: FilePath a File -> PathSegment
+basenameSeg (FilePath _ bname) = bname
 
 showp :: FilePath a b -> String
 showp RootPath = ""

--- a/data-filepath.cabal
+++ b/data-filepath.cabal
@@ -1,5 +1,5 @@
 name:                data-filepath
-version:             2.1.0.1
+version:             2.1.1.0
 synopsis:            A type safe file path data structure
 description:         A type safe file path data structure
 license:             BSD3


### PR DESCRIPTION
Here's an addition that exposes a standalone type for path segments.  I think this improves the ability to work with paths and partial paths.  There may be some missing interface functionality, but I'll let you decide how to handle the tradeoffs there with respect to backwards compatibility and API design preferences.