### PR TITLE
Made PathSegment instance of Semigroup instead of Monoid

### DIFF
--- a/data-filepath.cabal
+++ b/data-filepath.cabal
@@ -19,7 +19,12 @@ source-repository       head
     location:           https://github.com/maxpow4h/data-filepath.git
 
 library
-  exposed-modules:     Data.FilePath
-  other-extensions:    CPP, GADTs, DataKinds, KindSignatures, StandaloneDeriving, RankNTypes, DeriveDataTypeable, FlexibleInstances, MagicHash
-  build-depends:       base >=4.6 && <4.9, split >=0.2 && <0.3, template-haskell, ghc-prim
+  exposed-modules:      Data.FilePath
+  other-extensions:     CPP, GADTs, DataKinds, KindSignatures, StandaloneDeriving, RankNTypes, DeriveDataTypeable, FlexibleInstances, MagicHash
+  build-depends:        base                >= 4.6 && < 4.9
+                    ,   semigroups          == 0.16.*
+                    ,   split               >= 0.2 && < 0.3
+                    ,   template-haskell
+                    ,   ghc-prim
+
   default-language:    Haskell2010


### PR DESCRIPTION
Right now, `PathSegment` only does *some* of the checks upfront, the only check it leaves out is the null check on the string, so this means a function that creates a `FilePath` from a `PathSegment` can still only produce a `Maybe(FilePath ..)`, for e.g:

``` Haskell
-- Can only produce a Maybe (FilePath Relative Directory) since the null check must still happen.
mkDirPathSeg :: PathSegment -> Maybe (FilePath Relative Directory)
```
This kind of detracts from the usefulness of the type...

If `mkPathSegment` can be made to to do the null check also, and `PathSegment` also certifies the non-emptiness of the string then we can have a function like so:

``` Haskell
mkDirPathSeg :: PathSegment -> FilePath Relative Directory
```