### PR TITLE
Cleaned up the parse/mk API

### DIFF
--- a/data-filepath.cabal
+++ b/data-filepath.cabal
@@ -22,6 +22,7 @@ library
   exposed-modules:      Data.FilePath
   other-extensions:     CPP, GADTs, DataKinds, KindSignatures, StandaloneDeriving, RankNTypes, DeriveDataTypeable, FlexibleInstances, MagicHash
   build-depends:        base                >= 4.6 && < 4.9
+                    ,   bifunctors          == 4.2.*
                     ,   semigroups          == 0.16.*
                     ,   split               >= 0.2 && < 0.3
                     ,   template-haskell


### PR DESCRIPTION
@mightybyte 

An attempt to clean up the `parse` vs. `mk` API,

`parse*` functions now take "full" paths as strings and attempt to make type safe values, while the `mk*` functions do it a `PathSegment` at a time.

For the `parse*` family of functions I've tried to make it parse anything that is accepted on the UNIX command line. (e.g `/foo//bar` is valid just like `/foo/bar`.

Functions like `relativeFromWeak` and `rootFromWeak` can be combined with the `parse*` functions to get the more specific types if desired.