### PR TITLE
loosen/update dependency requirements

### DIFF
--- a/data-filepath.cabal
+++ b/data-filepath.cabal
@@ -1,5 +1,5 @@
 name:                data-filepath
-version:             2.2.0.0
+version:             2.2.0.1
 synopsis:            A type safe file path data structure
 description:         A type safe file path data structure
 license:             BSD3
@@ -21,9 +21,9 @@ source-repository       head
 library
   exposed-modules:      Data.FilePath
   other-extensions:     CPP, GADTs, DataKinds, KindSignatures, StandaloneDeriving, RankNTypes, DeriveDataTypeable, FlexibleInstances, MagicHash
-  build-depends:        base                >= 4.6 && < 4.9
-                    ,   bifunctors          == 4.2.*
-                    ,   semigroups          == 0.16.*
+  build-depends:        base                >= 4.6 && < 4.10
+                    ,   bifunctors          < 6.0
+                    ,   semigroups          < 0.19
                     ,   split               >= 0.2 && < 0.3
                     ,   template-haskell
                     ,   ghc-prim


### PR DESCRIPTION
Does not compile with `base == 4.9` because of Cabal requirements.

```
While constructing the build plan, the following exceptions were encountered:

In the dependencies for data-filepath-2.2.0.0:
    base-4.9.0.0 must match >=4.6 && <4.9 (latest applicable is 4.8.2.0)
    bifunctors-5.4.1 must match ==4.2.* (latest applicable is 4.2.1)
    semigroups-0.18.2 must match ==0.16.* (latest applicable is 0.16.2.2)
needed due to crawler-0.1.0.0 -> data-filepath-2.2.0.0
```
